### PR TITLE
errorDescription에 접근해서 사용가능하도록

### DIFF
--- a/library/src/main/kotlin/com/ridi/oauth2/AuthorizationFailedException.kt
+++ b/library/src/main/kotlin/com/ridi/oauth2/AuthorizationFailedException.kt
@@ -3,5 +3,5 @@ package com.ridi.oauth2
 class AuthorizationFailedException(
     val httpStatusCode: Int,
     val errorCode: String? = null,
-    errorDescription: String? = null
+    val errorDescription: String? = null
 ) : RuntimeException(errorDescription ?: "status=$httpStatusCode errorCode=$errorCode")


### PR DESCRIPTION
## 요약
- #8 에서 로그인 취약점 보완을 위해 API 응답데이터를 정상적으로 파싱할 수 없는 오류를 수정했습니다.
- 응답데이터의 description 필드를 사용해서 문구를 띄워주는 것으로 방향성이 확정되었는데, 파싱된 description필드에 접근해서 값을 빼내올 수 없어서 이를 수정합니다.

## 작업 내용
- `AuthorizationFailedException`의 `errorDescription`에 접근해서 값을 사용할 수 있도록 수정합니다.

## 궁금한 사항
- 인스턴스를 생성할때 errorDescription은 파라미터로 전달만 하고 property를 소유하고 있지 않아서 접근하지 못하고 있다고 이해하고 이렇게 수정했는데, 혹시 잘못되었거나 이미 접근이 가능한 상황이라면 코멘트 부탁드립니다.

## 이후 진행
- 반영하게 된다면 Changelog, 버전 갱신 -> 버전 tagging, 푸시 -> Jitpack에서 확인 후에 프로젝트에 적용 이렇게 진행하려고 합니다!